### PR TITLE
Add security benchmark tests group 6 (245-249)

### DIFF
--- a/BenchmarkTest00245.py
+++ b/BenchmarkTest00245.py
@@ -1,0 +1,10 @@
+#{fact rule=untrusted-deserialization@v1.0 defects=0}
+
+from ruamel.yaml import YAML
+
+
+#ok:avoid-unsafe-ruamel
+y3 = YAML(typ='safe')
+
+
+#{/fact}

--- a/BenchmarkTest00246.py
+++ b/BenchmarkTest00246.py
@@ -1,0 +1,10 @@
+#{fact rule=sensitive-information-leak@v1.0 defects=1}
+
+import socket
+
+# ruleid:avoid-bind-to-all-interfaces
+s = socket.socket(doesnt, matter)
+s.bind(('0.0.0.0', 1337))
+
+
+#{/fact}

--- a/BenchmarkTest00247.py
+++ b/BenchmarkTest00247.py
@@ -1,0 +1,12 @@
+#{fact rule=sensitive-information-leak@v1.0 defects=1}
+
+import socket
+
+
+
+# ruleid:avoid-bind-to-all-interfaces
+s = socket.socket(doesnt, matter)
+s.bind(('::', 1337))
+
+
+#{/fact}

--- a/BenchmarkTest00248.py
+++ b/BenchmarkTest00248.py
@@ -1,0 +1,10 @@
+#{fact rule=sensitive-information-leak@v1.0 defects=1}
+
+import socket
+
+# ruleid:avoid-bind-to-all-interfaces
+s = socket.socket(doesnt, matter)
+s.bind(('',))
+
+
+#{/fact}

--- a/BenchmarkTest00249.py
+++ b/BenchmarkTest00249.py
@@ -1,0 +1,11 @@
+#{fact rule=cross-site-scripting@v1.0 defects=1}
+
+from django.utils.safestring import SafeString, SafeData, SafeText
+
+
+# ruleid:class-extends-safestring
+class IWantToBypassEscaping3(SafeData):
+    def __init__(self):
+        super().__init__()
+
+#{/fact}


### PR DESCRIPTION
- BenchmarkTest00245.py: Ruamel YAML safe type usage
- BenchmarkTest00246.py: Socket bind to all interfaces vulnerability
- BenchmarkTest00247.py: Socket IPv6 bind vulnerability
- BenchmarkTest00248.py: Socket empty bind vulnerability
- BenchmarkTest00249.py: Django SafeData inheritance vulnerability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test covering safe YAML deserialization using a secure loader.
  * Added tests illustrating insecure socket binding to all interfaces (IPv4 and IPv6) for rule enforcement.
  * Added test demonstrating binding to all interfaces via empty host to validate detection.
  * Added test case around template escaping by subclassing a safe-string type to verify security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->